### PR TITLE
fix: Handle RunQuery request with new_transaction behaviour

### DIFF
--- a/.changeset/short-melons-listen.md
+++ b/.changeset/short-melons-listen.md
@@ -1,0 +1,5 @@
+---
+"@firestore-emulator/server": patch
+---
+
+Handle RunQuery request with new_transaction behaviour. Clients now can use RunQuery as the first request within a transaction.

--- a/examples/firebase-admin-vitest/src/__snapshots__/index.test.ts.snap
+++ b/examples/firebase-admin-vitest/src/__snapshots__/index.test.ts.snap
@@ -819,6 +819,42 @@ exports[`transaction > get and set in transaction 1`] = `
 }
 `;
 
+exports[`transaction > query in transaction 1`] = `
+{
+  "projects": {
+    "test-project": {
+      "databases": {
+        "(default)": {
+          "collections": {
+            "users": {
+              "documents": {
+                "alice": {
+                  "collections": {},
+                  "fields": {
+                    "age": {
+                      "type": "integer_value",
+                      "value": 20,
+                    },
+                    "name": {
+                      "type": "string_value",
+                      "value": "Alice",
+                    },
+                  },
+                  "path": "projects/test-project/databases/(default)/documents/users/alice",
+                },
+              },
+              "path": "projects/test-project/databases/(default)/documents/users",
+            },
+          },
+          "path": "projects/test-project/databases/(default)/documents",
+        },
+      },
+      "path": "projects/test-project",
+    },
+  },
+}
+`;
+
 exports[`transaction > set in transaction 1`] = `
 {
   "projects": {

--- a/examples/firebase-admin-vitest/src/index.test.ts
+++ b/examples/firebase-admin-vitest/src/index.test.ts
@@ -531,6 +531,25 @@ describe("transaction", () => {
     expect(emulatorResult.value.data()).toEqual(realResult.value.data());
     expect(emulator.state.toJSON()).toMatchSnapshot();
   });
+  it("query in transaction", async () => {
+    const [realResult, emulatorResult] = await testCase(async (db) => {
+      await db.collection("users").doc("alice").set({
+        age: 20,
+        name: "Alice",
+      });
+      return await db.runTransaction(async (transaction) => {
+        return await transaction.get(
+          db.collection("users").where("age", "==", 20).limit(1),
+        );
+      });
+    });
+    assert(realResult.status === "fulfilled");
+    assert(emulatorResult.status === "fulfilled");
+    expect(emulatorResult.value.docs.map((doc) => doc.data())).toEqual(
+      realResult.value.docs.map((doc) => doc.data()),
+    );
+    expect(emulator.state.toJSON()).toMatchSnapshot();
+  });
 });
 
 describe("FieldValue", () => {

--- a/examples/firebase-admin/src/__snapshots__/index.test.ts.snap
+++ b/examples/firebase-admin/src/__snapshots__/index.test.ts.snap
@@ -956,6 +956,42 @@ exports[`transaction get and set in transaction 1`] = `
 }
 `;
 
+exports[`transaction query in transaction 1`] = `
+{
+  "projects": {
+    "test-project": {
+      "databases": {
+        "(default)": {
+          "collections": {
+            "users": {
+              "documents": {
+                "alice": {
+                  "collections": {},
+                  "fields": {
+                    "age": {
+                      "type": "integer_value",
+                      "value": 20,
+                    },
+                    "name": {
+                      "type": "string_value",
+                      "value": "Alice",
+                    },
+                  },
+                  "path": "projects/test-project/databases/(default)/documents/users/alice",
+                },
+              },
+              "path": "projects/test-project/databases/(default)/documents/users",
+            },
+          },
+          "path": "projects/test-project/databases/(default)/documents",
+        },
+      },
+      "path": "projects/test-project",
+    },
+  },
+}
+`;
+
 exports[`transaction set in transaction 1`] = `
 {
   "projects": {

--- a/examples/firebase-admin/src/index.test.ts
+++ b/examples/firebase-admin/src/index.test.ts
@@ -530,6 +530,25 @@ describe("transaction", () => {
     expect(emulatorResult.value.data()).toEqual(realResult.value.data());
     expect(emulator.state.toJSON()).toMatchSnapshot();
   });
+  it("query in transaction", async () => {
+    const [realResult, emulatorResult] = await testCase(async (db) => {
+      await db.collection("users").doc("alice").set({
+        age: 20,
+        name: "Alice",
+      });
+      return await db.runTransaction(async (transaction) => {
+        return await transaction.get(
+          db.collection("users").where("age", "==", 20).limit(1),
+        );
+      });
+    });
+    assert(realResult.status === "fulfilled");
+    assert(emulatorResult.status === "fulfilled");
+    expect(emulatorResult.value.docs.map((doc) => doc.data())).toEqual(
+      realResult.value.docs.map((doc) => doc.data()),
+    );
+    expect(emulator.state.toJSON()).toMatchSnapshot();
+  });
 });
 
 describe("FieldValue", () => {

--- a/package.json
+++ b/package.json
@@ -14,5 +14,10 @@
     "turbo": "2.3.4"
   },
   "packageManager": "pnpm@10.3.0",
-  "name": "firestore-emulator"
+  "name": "firestore-emulator",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "grpc-tools"
+    ]
+  }
 }

--- a/packages/server/src/server/FirestoreServiceV1Impl/index.ts
+++ b/packages/server/src/server/FirestoreServiceV1Impl/index.ts
@@ -179,6 +179,11 @@ export class FirestoreServiceV1Impl extends UnimplementedFirestoreService {
       call.request.structured_query,
     );
 
+    let transaction: Uint8Array | undefined = call.request.transaction;
+    if (call.request.consistency_selector === "new_transaction") {
+      transaction = crypto.getRandomValues(new Uint8Array(12));
+    }
+
     if (results.length > 0) {
       results.forEach((result, i, arr) => {
         call.write(
@@ -187,7 +192,7 @@ export class FirestoreServiceV1Impl extends UnimplementedFirestoreService {
             done: i === arr.length - 1,
             read_time: TimestampFromDate(date),
             skipped_results: 0,
-            transaction: call.request.transaction,
+            transaction,
           }),
         );
       });
@@ -197,7 +202,7 @@ export class FirestoreServiceV1Impl extends UnimplementedFirestoreService {
           done: true,
           read_time: TimestampFromDate(date),
           skipped_results: 0,
-          transaction: call.request.transaction,
+          transaction,
         }),
       );
     }


### PR DESCRIPTION
With the following snippet, Firestore Client will throw an error:

```js
return await db.runTransaction(async (transaction) => {
  return await transaction.get(
    db.collection("users"),
  );
});
```

```
Error: Transaction ID was missing from server response
    at /Users/naoki.ikeguchi/.local/src/github.com/YutaUra/firestore-emulator/node_modules/.pnpm/@google-cloud+firestore@7.10.0_encoding@0.1.13/node_modules/@google-cloud/firestore/build/src/transaction.js:494:31
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
```

After looking at the protobuf payload, I noticed that the `FirestoreServiceV1Impl` does not handle some behaviour when `consistency_selector` is set to [`new_transaction`](https://github.com/googleapis/googleapis/blob/40bad3ea0d48ecf250296ea7438035b8e45227dd/google/firestore/v1/firestore.proto#L571).

When the client issued the first request within a transaction, the request does not contain any transaction ID yet. The current implementation only echo-backs the transaction ID in the request, regardless of its presence. I added an if switch to generate a new transaction ID to make the client happy.

---

Plus, I added `grpc-tools` to `package.json#pnpm.onlyBuiltDependencies`. pnpm (since v10) does not run build scripts by default, but the `generate` script needs `grpc-tools` to be built.